### PR TITLE
Fix compiler warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           sync_files: runner-to-vm
           shell: bash
           run: |
-            sudo pkgin install autoconf automake libtool
+            sudo pkgin -y install autoconf automake libtool
             autoreconf -vfi
             ./configure
             make

--- a/src/bmc.c
+++ b/src/bmc.c
@@ -1,4 +1,5 @@
 /*-
+ * Copyright (c) 2015-2024 Ioannis Konstantelias,
  * Copyright (c) 2012-2015 Wojciech Owczarek,
  * Copyright (c) 2011-2012 George V. Neville-Neil,
  *                         Steven Kreuzer,
@@ -677,10 +678,10 @@ bmcStateDecision(ForeignMasterRecord *foreign, const RunTimeOpts *rtOpts, PtpClo
 			ptpClock->counters.bestMasterChanges++;
 			if (ptpClock->portDS.portState == PTP_SLAVE)
 				displayStatus(ptpClock, "State: ");
-				if(rtOpts->calibrationDelay) {
-					ptpClock->isCalibrated = FALSE;
-					timerStart(&ptpClock->timers[CALIBRATION_DELAY_TIMER], rtOpts->calibrationDelay);
-				}
+			if(rtOpts->calibrationDelay) {
+				ptpClock->isCalibrated = FALSE;
+				timerStart(&ptpClock->timers[CALIBRATION_DELAY_TIMER], rtOpts->calibrationDelay);
+			}
 		}
                 if(rtOpts->unicastNegotiation && ptpClock->parentGrants != NULL) {
                         ptpClock->portDS.logAnnounceInterval = ptpClock->parentGrants->grantData[ANNOUNCE_INDEXED].logInterval;

--- a/src/dep/daemonconfig.c
+++ b/src/dep/daemonconfig.c
@@ -1,4 +1,5 @@
 /*-
+ * Copyright (c) 2015-2024 Ioannis Konstantelias,
  * Copyright (c) 2013-2015 Wojciech Owczarek,
  *
  * All Rights Reserved
@@ -854,6 +855,8 @@ parseConfig ( int opCode, void *opArg, dictionary* dict, RunTimeOpts *rtOpts )
 	 * is complete and free of any unknown options. In the end, warning
 	 * is issued for unknown options. On any errors, NULL is returned
 	 */
+
+	int ret;
 
 	dictionary* target = dictionary_new(0);
 
@@ -2447,21 +2450,32 @@ parseConfig ( int opCode, void *opArg, dictionary* dict, RunTimeOpts *rtOpts )
 	 */
 	if(rtOpts->autoLockFile) {
 
-	    memset(rtOpts->lockFile, 0, PATH_MAX);
-	    snprintf(rtOpts->lockFile, PATH_MAX,
-		    "%s/"PTPD_PROGNAME"_%s_%s.lock",
-		    rtOpts->lockDirectory,
-		    (rtOpts->clockQuality.clockClass<128 && !rtOpts->slaveOnly) ? "master" : DEFAULT_CLOCKDRIVER,
-		    rtOpts->ifaceName);
-	    DBG("Automatic lock file name is: %s\n", rtOpts->lockFile);
+		memset(rtOpts->lockFile, 0, PATH_MAX);
+		ret = snprintf(rtOpts->lockFile, PATH_MAX,
+				"%s/"PTPD_PROGNAME"_%s_%s.lock",
+				rtOpts->lockDirectory,
+				(rtOpts->clockQuality.clockClass<128 && !rtOpts->slaveOnly) ? "master" : DEFAULT_CLOCKDRIVER,
+				rtOpts->ifaceName);
+		if (ret < 0) {
+			ERROR("The lock file name failed to be written\n", rtOpts->lockFile);
+		} else if (ret > PATH_MAX) {
+			WARNING("The lock file name has been truncated\n", rtOpts->lockFile);
+		}
+		DBG("Automatic lock file name is: %s\n", rtOpts->lockFile);
 	/*
 	 * Otherwise use default lock file name, with the specified lock directory
 	 * which will be set do default from constants_dep.h if not configured
 	 */
 	} else {
-		if(!CONFIG_ISSET("global:lock_file"))
-			snprintf(rtOpts->lockFile, PATH_MAX,
-				"%s/%s", rtOpts->lockDirectory, DEFAULT_LOCKFILE_NAME);
+		if(!CONFIG_ISSET("global:lock_file")) {
+			ret = snprintf(rtOpts->lockFile, PATH_MAX,
+					"%s/%s", rtOpts->lockDirectory, DEFAULT_LOCKFILE_NAME);
+			if (ret < 0) {
+				ERROR("The lock file name failed to be written\n", rtOpts->lockFile);
+			} else if (ret > PATH_MAX) {
+				WARNING("The lock file name has been truncated\n", rtOpts->lockFile);
+			}
+		}
 	}
 
 /* ==== END additional logic */
@@ -2522,7 +2536,7 @@ loadCommandLineKeys(dictionary* dict, int argc,char** argv)
 {
 
     int i;
-    char key[PATH_MAX],val[PATH_MAX];
+    char key[PATH_MAX],val[PATH_MAX+1];
 
     for ( i=0; i<argc; i++) {
 

--- a/src/dep/iniparser/dictionary.c
+++ b/src/dep/iniparser/dictionary.c
@@ -61,11 +61,14 @@ static void * mem_double(void * ptr, int size)
 static char * xstrdup(const char * s)
 {
     char * t ;
+    size_t len;
     if (!s)
         return NULL ;
-    t = (char*)calloc(strlen(s)+1,sizeof(char)) ;
+
+    len = strlen(s) + 1;
+    t = (char*) malloc(len) ;
     if (t) {
-        strncpy(t,s,strlen(s));
+        memcpy(t,s,len);
     }
     return t ;
 }

--- a/src/dep/iniparser/iniparser.c
+++ b/src/dep/iniparser/iniparser.c
@@ -638,7 +638,7 @@ dictionary * iniparser_load(const char * ininame)
     char line    [ASCIILINESZ+1] ;
     char section [ASCIILINESZ+1] ;
     char key     [ASCIILINESZ+1] ;
-    char tmp     [ASCIILINESZ+1] ;
+    char tmp     [(ASCIILINESZ * 2) + 2] ;
     char val     [ASCIILINESZ+1] ;
 
     int  last=0 ;
@@ -663,7 +663,6 @@ dictionary * iniparser_load(const char * ininame)
     memset(section, 0, ASCIILINESZ);
     memset(key,     0, ASCIILINESZ);
     memset(val,     0, ASCIILINESZ);
-    memset(tmp,     0, ASCIILINESZ);
     last=0 ;
 
     while (fgets(line+last, ASCIILINESZ-last, in)!=NULL) {
@@ -705,7 +704,7 @@ dictionary * iniparser_load(const char * ininame)
             break ;
 
             case LINE_VALUE:
-            snprintf(tmp, ASCIILINESZ, "%s%s%s", section, strlen(section)==0?"":":", key);
+            sprintf(tmp, "%s%s%s", section, strlen(section)==0?"":":", key);
             errs = dictionary_set(dict, tmp, val) ;
             break ;
 

--- a/src/dep/net.c
+++ b/src/dep/net.c
@@ -1070,7 +1070,7 @@ netInit(NetPath * netPath, RunTimeOpts * rtOpts, PtpClock * ptpClock)
 	if( !netPath->interfaceInfo.hasHwAddress && netPath->interfaceInfo.hasAfAddress ) {
 		uint32_t addr = ((struct sockaddr_in*)&(netPath->interfaceInfo.afAddress))->sin_addr.s_addr;
 		memcpy(netPath->interfaceID, &addr, 2);
-		memcpy(netPath->interfaceID + 4, &addr + 2, 2);
+		memcpy(netPath->interfaceID + 4, (Octet *)&addr + 2, 2);
 	/* Initialise interfaceID with hardware address */
 	} else {
 		    memcpy(&netPath->interfaceID, &netPath->interfaceInfo.hwAddress,

--- a/src/dep/net.c
+++ b/src/dep/net.c
@@ -1,4 +1,5 @@
 /*-
+ * Copyright (c) 2015-2024 Ioannis Konstantelias,
  * Copyright (c) 2014-2015 Wojciech Owczarek,
  *                         George V. Neville-Neil
  * Copyright (c) 2012-2013 George V. Neville-Neil,
@@ -2017,7 +2018,7 @@ netSendEvent(Octet * buf, UInteger16 length, NetPath * netPath,
 
 ssize_t
 netSendGeneral(Octet * buf, UInteger16 length, NetPath * netPath,
-	       const const RunTimeOpts *rtOpts, Integer32 destinationAddress)
+	       const RunTimeOpts *rtOpts, Integer32 destinationAddress)
 {
 	ssize_t ret;
 	struct sockaddr_in addr;

--- a/src/dep/outlierfilter.c
+++ b/src/dep/outlierfilter.c
@@ -1,4 +1,5 @@
 /*-
+ * Copyright (c) 2014-2024 Ioannis Konstantelias,
  * Copyright (c) 2014      Wojciech Owczarek,
  *
  * All Rights Reserved
@@ -82,7 +83,7 @@ outlierFilterInit(OutlierFilter *filter, OutlierFilterConfig *config, const char
 	 if (config->enabled) {
                 filter->rawStats = createDoubleMovingStdDev(config->capacity);
                 strncpy(filter->id, id, OUTLIERFILTER_MAX_DESC);
-                strncpy(filter->rawStats->identifier, id, 10);
+                strncpy(filter->rawStats->identifier, id, 9);
                 filter->filteredStats = createDoubleMovingMean(config->capacity);
                 filter->threshold = config->threshold;
         } else {

--- a/src/dep/servo.c
+++ b/src/dep/servo.c
@@ -1,4 +1,5 @@
 /*-
+ * Copyright (c) 2015-2024 Ioannis Konstantelias,
  * Copyright (c) 2012-2015 Wojciech Owczarek,
  * Copyright (c) 2011-2012 George V. Neville-Neil,
  *                         Steven Kreuzer,
@@ -1035,7 +1036,7 @@ updateClock(const RunTimeOpts * rtOpts, PtpClock * ptpClock)
 }
 
 void
-setupPIservo(PIservo* servo, const const RunTimeOpts* rtOpts)
+setupPIservo(PIservo* servo, const RunTimeOpts* rtOpts)
 {
     servo->maxOutput = rtOpts->servoMaxPpb;
     servo->kP = rtOpts->servoKP;

--- a/src/dep/statistics.c
+++ b/src/dep/statistics.c
@@ -1,4 +1,5 @@
 /*-
+ * Copyright (c) 2015-2024 Ioannis Konstantelias,
  * Copyright (c) 2013-2015 Wojciech Owczarek
  *
  * All Rights Reserved
@@ -590,7 +591,7 @@ IntMovingStatFilter* createIntMovingStatFilter(StatFilterOptions *config, const 
 
 	if(config->windowSize < 2) container->windowType = WINDOW_SLIDING;
 
-	strncpy(container->identifier, id, 10);
+	strncpy(container->identifier, id, 9);
 
 	return container;
 
@@ -749,7 +750,7 @@ DoubleMovingStatFilter* createDoubleMovingStatFilter(StatFilterOptions *config, 
 
 	if(config->windowSize < 2) container->windowType = WINDOW_SLIDING;
 
-	strncpy(container->identifier, id, 10);
+	strncpy(container->identifier, id, 9);
 
 	return container;
 

--- a/src/dep/sys.c
+++ b/src/dep/sys.c
@@ -282,7 +282,7 @@ int ether_ntohost_cache(char *hostname, struct ether_addr *addr)
 	}
 
 	valid = 1;
-	strncpy(hostname, buf, 100);
+	memcpy(hostname, buf, 100);
 	return 0;
 }
 
@@ -293,7 +293,7 @@ snprint_ClockIdentity_ntohost(char *s, int max_len, const ClockIdentity id)
 {
 	int len = 0;
 	int i,j;
-	char  buf[100];
+	char  buf[101];
 	struct ether_addr e;
 
 	/* extract mac address */
@@ -310,6 +310,7 @@ snprint_ClockIdentity_ntohost(char *s, int max_len, const ClockIdentity id)
 	}
 
 	/* convert and print hostname */
+	memset(buf, 0, 101);
 	ether_ntohost_cache(buf, &e);
 	len += snprintf(&s[len], max_len - len, "(%s)", buf);
 
@@ -576,6 +577,7 @@ closeLog(LogFileHandler* handler)
 Boolean
 maintainLogSize(LogFileHandler* handler)
 {
+	int len;
 
 	if(handler->maxSize) {
 		if(handler->logFP == NULL)
@@ -593,11 +595,17 @@ maintainLogSize(LogFileHandler* handler)
 			int logFileNumber = 0;
 			time_t maxMtime = 0;
 			struct stat st;
-			char fname[PATH_MAX];
+			char fname[PATH_MAX + 1];
 			/* Find the last modified file of the series */
 			while(++i <= handler->maxFiles) {
 				memset(fname, 0, PATH_MAX);
-				snprintf(fname, PATH_MAX,"%s.%d", handler->logPath, i);
+				len = snprintf(fname, PATH_MAX,"%s.%d", handler->logPath, i);
+				if (len < 0) {
+					ERROR("Log file name failed to be written\n");
+					break;
+				} else if (len > PATH_MAX) {
+					WARNING("Log file name has been truncated\n");
+				}
 				if((stat(fname,&st) != -1) && S_ISREG(st.st_mode)) {
 					if(st.st_mtime > maxMtime) {
 						maxMtime = st.st_mtime;
@@ -609,7 +617,12 @@ maintainLogSize(LogFileHandler* handler)
 			if(++logFileNumber > handler->maxFiles)
 				logFileNumber = 1;
 			memset(fname, 0, PATH_MAX);
-			snprintf(fname, PATH_MAX,"%s.%d", handler->logPath, logFileNumber);
+			len = snprintf(fname, PATH_MAX,"%s.%d", handler->logPath, logFileNumber);
+			if (len < 0) {
+				ERROR("Log file name failed to be written\n");
+			} else if (len > PATH_MAX) {
+				WARNING("Log file name has been truncated\n");
+			}
 			/* Move current file to new location */
 			rename(handler->logPath, fname);
 			/* Reopen to reactivate the original path */
@@ -1741,6 +1754,7 @@ int lockPid = 0;
 glob_t matchedFiles;
 Boolean ret = TRUE;
 int matches = 0, counter = 0;
+int len;
 
 	/* no need to check locks */
 	if(rtOpts->ignore_daemon_lock ||
@@ -1754,8 +1768,13 @@ int matches = 0, counter = 0;
      */
 
 	/* Check for other ptpd running on the same interface - same for all modes */
-	snprintf(searchPattern, PATH_MAX,"%s/%s_*_%s.lock",
-	    rtOpts->lockDirectory, PTPD_PROGNAME,rtOpts->ifaceName);
+	len = snprintf(searchPattern, PATH_MAX,"%s/%s_*_%s.lock",
+			rtOpts->lockDirectory, PTPD_PROGNAME,rtOpts->ifaceName);
+	if (len < 0) {
+		ERROR("Search pattern failed to be written\n");
+	} else if (len > PATH_MAX) {
+		WARNING("Search pattern has been truncated\n");
+	}
 
 	DBGV("SearchPattern: %s\n",searchPattern);
 	switch(glob(searchPattern, 0, NULL, &matchedFiles)) {
@@ -1800,8 +1819,13 @@ int matches = 0, counter = 0;
 		globfree(&matchedFiles);
 	/* Any mode that can control the clock - also check the clock driver */
 	if(rtOpts->clockQuality.clockClass > 127 ) {
-	    snprintf(searchPattern, PATH_MAX,"%s/%s_%s_*.lock",
-	    rtOpts->lockDirectory,PTPD_PROGNAME,DEFAULT_CLOCKDRIVER);
+		len = snprintf(searchPattern, PATH_MAX,"%s/%s_%s_*.lock",
+				rtOpts->lockDirectory,PTPD_PROGNAME,DEFAULT_CLOCKDRIVER);
+		if (len < 0) {
+			ERROR("Search pattern failed to be written\n");
+		} else if (len > PATH_MAX) {
+			WARNING("Search pattern has been truncated\n");
+		}
 	DBGV("SearchPattern: %s\n",searchPattern);
 
 	switch(glob(searchPattern, 0, NULL, &matchedFiles)) {

--- a/src/dep/sys.c
+++ b/src/dep/sys.c
@@ -1,4 +1,5 @@
 /*-
+ * Copyright (c) 2015-2024 Ioannis Konstantelias,
  * Copyright (c) 2012-2015 Wojciech Owczarek,
  * Copyright (c) 2011-2012 George V. Neville-Neil,
  *                         Steven Kreuzer,
@@ -1053,9 +1054,9 @@ writeStatusFile(PtpClock *ptpClock,const RunTimeOpts *rtOpts, Boolean quiet)
 	    memset(tmpBuf, 0, sizeof(tmpBuf));
 	    snprint_PortIdentity(tmpBuf, sizeof(tmpBuf),
 	    &ptpClock->parentDS.parentPortIdentity);
-	fprintf(out, 		STATUSPREFIX"  %s","Best master ID", tmpBuf);
-	if(ptpClock->portDS.portState == PTP_MASTER)
-	    fprintf(out," (self)");
+	    fprintf(out, 		STATUSPREFIX"  %s","Best master ID", tmpBuf);
+	    if(ptpClock->portDS.portState == PTP_MASTER)
+	        fprintf(out," (self)");
 	    fprintf(out,"\n");
 	}
 	if(rtOpts->transport == UDP_IPV4 &&
@@ -2212,7 +2213,7 @@ restoreDrift(PtpClock * ptpClock, const RunTimeOpts * rtOpts, Boolean quiet)
 				INFO("Observed drift loaded from %s: "DRIFTFORMAT" ppb\n",
 					rtOpts->driftFile,
 					recovered_drift);
-				break;
+			break;
 			}
 
 		case DRIFT_KERNEL:

--- a/src/management.c
+++ b/src/management.c
@@ -1,4 +1,5 @@
 /*-
+ * Copyright (c) 2015-2024 Ioannis Konstantelias,
  * Copyright (c) 2012-2015 Wojciech Owczarek,
  * Copyright (c) 2011-2012 George V. Neville-Neil,
  *                         Steven Kreuzer,
@@ -603,7 +604,7 @@ void handleMMClockDescription(MsgManagement* incoming, MsgManagement* outgoing, 
 		/* reserved */
 		data->reserved = 0;
 		/* product description */
-		tmpsnprintf(tmpStr, 64, PRODUCT_DESCRIPTION, rtOpts->productDescription);
+		tmpsnprintf(tmpStr, 80, PRODUCT_DESCRIPTION, rtOpts->productDescription);
                 data->productDescription.lengthField = strlen(tmpStr);
                 XMALLOC(data->productDescription.textField,
                                         data->productDescription.lengthField);
@@ -1211,7 +1212,7 @@ void handleMMLogAnnounceInterval(MsgManagement* incoming, MsgManagement* outgoin
 		data = (MMLogAnnounceInterval*)incoming->tlv->dataField;
 		/* SET actions */
 		ptpClock->portDS.logAnnounceInterval = data->logAnnounceInterval;
-		tmpsnprintf(tmpStr, 4, "%d", data->logAnnounceInterval);
+		tmpsnprintf(tmpStr, 6, "%d", data->logAnnounceInterval);
 		setConfig(ptpClock->managementConfig, "ptpengine:log_announce_interval", tmpStr);
 		ptpClock->record_update = TRUE;
 		/* intentionally fall through to GET case */
@@ -1299,7 +1300,7 @@ void handleMMLogSyncInterval(MsgManagement* incoming, MsgManagement* outgoing, P
 		data = (MMLogSyncInterval*)incoming->tlv->dataField;
 		/* SET actions */
 		ptpClock->portDS.logSyncInterval = data->logSyncInterval;
-		tmpsnprintf(tmpStr, 4, "%d", data->logSyncInterval);
+		tmpsnprintf(tmpStr, 6, "%d", data->logSyncInterval);
 		setConfig(ptpClock->managementConfig, "ptpengine:log_sync_interval", tmpStr);
 		ptpClock->record_update = TRUE;
 		/* intentionally fall through to GET case */
@@ -1764,7 +1765,7 @@ void handleMMLogMinPdelayReqInterval(MsgManagement* incoming, MsgManagement* out
 		data = (MMLogMinPdelayReqInterval*)incoming->tlv->dataField;
 		/* SET actions */
 		ptpClock->portDS.logMinPdelayReqInterval = data->logMinPdelayReqInterval;
-		tmpsnprintf(tmpStr, 4, "%d", data->logMinPdelayReqInterval);
+		tmpsnprintf(tmpStr, 6, "%d", data->logMinPdelayReqInterval);
 		setConfig(ptpClock->managementConfig, "ptpengine:log_peer_delayreq_interval", tmpStr);
 		ptpClock->record_update = TRUE;
 		/* intentionally fall through to GET case */

--- a/src/signaling.c
+++ b/src/signaling.c
@@ -1,4 +1,5 @@
 /*-
+ * Copyright (c) 2015-2024 Ioannis Konstantelias
  * Copyright (c) 2015 	   Wojciech Owczarek
  * Copyright (c) 2014 	   Perseus Telecom
  *
@@ -56,7 +57,7 @@ static void handleSMAcknowledgeCancelUnicastTransmission(MsgSignaling* incoming,
 static Boolean prepareSMRequestUnicastTransmission(MsgSignaling* outgoing, UnicastGrantData *grant, PtpClock* ptpClock);
 static Boolean prepareSMCancelUnicastTransmission(MsgSignaling* outgoing, UnicastGrantData* grant, PtpClock* ptpClock);
 static void requestUnicastTransmission(UnicastGrantData *grant, UInteger32 duration, const RunTimeOpts* rtOpts, PtpClock* ptpClock);
-static void issueSignaling(MsgSignaling *outgoing, Integer32 destination, const const RunTimeOpts *rtOpts, PtpClock *ptpclock);
+static void issueSignaling(MsgSignaling *outgoing, Integer32 destination, const RunTimeOpts *rtOpts, PtpClock *ptpclock);
 static void cancelNodeGrants(UnicastGrantTable *nodeTable, const RunTimeOpts *rtOpts, PtpClock *ptpClock);
 
 /* Return unicast grant array index for given message type */
@@ -959,7 +960,7 @@ requestUnicastTransmission(UnicastGrantData *grant, UInteger32 duration, const R
 }
 
 void
-cancelUnicastTransmission(UnicastGrantData* grant, const const RunTimeOpts* rtOpts, PtpClock* ptpClock)
+cancelUnicastTransmission(UnicastGrantData* grant, const RunTimeOpts* rtOpts, PtpClock* ptpClock)
 {
 
 /* todo: dbg sending */
@@ -979,7 +980,7 @@ cancelUnicastTransmission(UnicastGrantData* grant, const const RunTimeOpts* rtOp
 }
 
 static void
-issueSignaling(MsgSignaling *outgoing, Integer32 destination, const const RunTimeOpts *rtOpts,
+issueSignaling(MsgSignaling *outgoing, Integer32 destination, const RunTimeOpts *rtOpts,
 		PtpClock *ptpClock)
 {
 


### PR DESCRIPTION
The goal is to have cleaner builds.

Fixes include:
 - misleading indentation
   - Fixed by fixing indentation
   - The indentation is still messed up, but it's not ambiguous
 - double-`const`
 - copying of wrong data with `memcpy`
 - wrong buffer sizes used with `strncpy` and `snprintf`