### PR TITLE
Fix broken compliance check

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,7 +1,6 @@
 name: Compliance
 
 on:
-  push: {}
   pull_request: {}
 
 jobs:
@@ -9,8 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Install dependencies
         run: sudo apt install clang-format
       - name: Check Formatting Style (clang-format)
         run: |
-          sh ./scripts/check_format.sh ${{ github.event.pull_request.base.ref }}
+          sh ./scripts/check_format.sh origin/${{ github.base_ref }}

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -2,7 +2,7 @@
 
 commit=$1
 
-cmd="git diff -U0 --no-color $commit | clang-format-diff -p1"
+cmd="git diff -U0 --no-color $commit -- '*.c' '*.h' | clang-format-diff -p1"
 diff=$(eval "$cmd")
 if [ $? -ne 0 ]
 then


### PR DESCRIPTION
Fixes:

- Attempts to format files other than .c and .h, eg. .json.
- CI job wouldn't show any differences because it didn't compare the current work with the target branch.